### PR TITLE
fix chart rendering errors

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Generate a random cookie secret if none is provided
 */}}
 {{- define "headplane.cookieSecret" -}}
-{{- if and .Values.headplane.secret.server (hasKey .Values.headplane.secret.server "cookie_secret") .Values.headplane.secret.server.cookie_secret -}}
+{{- if and .Values.headplane.secret .Values.headplane.secret.server (hasKey .Values.headplane.secret.server "cookie_secret") .Values.headplane.secret.server.cookie_secret -}}
 {{- .Values.headplane.secret.server.cookie_secret -}}
 {{- else -}}
 {{- randAlphaNum 32 -}}

--- a/templates/secret-headplane.yaml
+++ b/templates/secret-headplane.yaml
@@ -13,7 +13,6 @@ stringData:
 {{- toYaml .Values.headplane.config.headscale | nindent 6 }}
     integration:
 {{- toYaml .Values.headplane.config.integration | nindent 6 }}
-# only add oidc if .Values.headplane.oidc is set
 {{- if .Values.headplane.oidc.enabled }}
     oidc:
       issuer: {{ .Values.headplane.oidc.issuer | quote }}


### PR DESCRIPTION
This fixes a few errors when rendering the chart (test with `helm template headplane . -f test-values.yaml`)

```sh
$ helm version                                                                
version.BuildInfo{Version:"v3.17.3", GitCommit:"e4da49785aa6e6ee2b86efd5dd9e43400318262b", GitTreeState:"", GoVersion:"go1.24.2"}
```

test-values.yaml

```yaml
headplane:
  config:
    headscale:
      url: "https://vpn.test.example.com"
  secret:
    server:
      cookie_secret: "test-cookie-secret-12345"
  oidc:
    client_id: "test-headplane-client-id"
    enabled: true
    issuer: "https://auth.test.example.com"
    redirect_uri: "https://headplane.test.example.com/admin/oidc/callback"
headscale:
  config:
    server_url: "https://vpn.test.example.com"
    dns:
      base_domain: "test.vpn"
  oidc:
    client_id: "test-headscale-client-id"
    enabled: true
    issuer: "https://auth.test.example.com"
pvc:
  storageClassName: "test-class-sc"
```