### PR TITLE
Headplane config fix + PKCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ helm uninstall headplane
 | headscale.oidc.client_id | string | `"YOUR_OIDC_CLIENT_ID_FOR_HEADSCALE"` |  |
 | headscale.oidc.enabled | bool | `false` |  |
 | headscale.oidc.issuer | string | `"https://your-oidc-issuer.com"` |  |
+| headscale.oidc.pkce.enabled | bool | `false` |  |
+| headscale.oidc.pkce.method | string | `"S256"` |  |
 | headscale.oidc.secret_name | string | `"oidc-secrets"` |  |
 | ingress.annotations | list | `[]` |  |
 | ingress.className | string | `"nginx"` |  |

--- a/templates/secret-headplane.yaml
+++ b/templates/secret-headplane.yaml
@@ -20,4 +20,7 @@ stringData:
       token_endpoint_auth_method: {{ .Values.headplane.oidc.token_endpoint_auth_method | quote }}
       redirect_uri: {{ .Values.headplane.oidc.redirect_uri | quote }}
       client_id: {{ .Values.headplane.oidc.client_id | quote }}
-{{- end }} 
+      {{- if .Value.headplane.oidc.disable_api_key_login }}
+      headscale_api_key: "PLACEHOLDER_REPLACED_BY_ENV"
+{{- end }}
+{{- end }}

--- a/templates/secret-headscale.yaml
+++ b/templates/secret-headscale.yaml
@@ -7,7 +7,7 @@ type: Opaque
 stringData:
   config.yaml: |
 {{- toYaml .Values.headscale.config | nindent 4 }}
-{{- if .Values.headscale.oidc.enabled }}
+  {{- if .Values.headscale.oidc.enabled }}
     oidc:
       issuer: {{ .Values.headscale.oidc.issuer | quote }}
       client_id: {{ .Values.headscale.oidc.client_id | quote }}
@@ -23,4 +23,9 @@ stringData:
       allowed_users:
         {{- toYaml .Values.headscale.oidc.allowed_users | nindent 8 }}
       {{- end }}
-{{- end }} 
+      {{- if .Values.headscale.oidc.pkce.enabled }}
+      pkce:
+        enabled: {{ .Values.headscale.oidc.pkce.enabled | quote }}
+        method: {{ .Values.headscale.oidc.pkce.method | quote }}
+      {{- end }}
+{{- end }}

--- a/templates/statefulset-headplane.yaml
+++ b/templates/statefulset-headplane.yaml
@@ -49,7 +49,6 @@ spec:
           {{- if .Values.headplane.oidc.enabled }}
           - secretRef:
               name: {{ .Values.headplane.oidc.secret_name }}
-              # optional: true
           {{- end }}
           {{- with .Values.headplane.envFrom }}
           {{- toYaml . | nindent 10 }}

--- a/values.yaml
+++ b/values.yaml
@@ -66,6 +66,9 @@ headscale:
     client_id: "YOUR_OIDC_CLIENT_ID_FOR_HEADSCALE"
     # Name of the secret containing OIDC credentials
     secret_name: "oidc-secrets"
+    pkce:
+      enabled: false
+      method: S256
   config:
     # The public URL for the Headscale server
     server_url: https://vpn.example.com


### PR DESCRIPTION
2 fix:
- Add a way to enable PKCE in headscale
- Fix oidc.headscale_api_key missing error in headplane

Not sure if the headplane config fix should be here or if it's intended on headplane side, but since it's not starting without it I added it

I also have an error in headplane
```
2025-06-22T17:48:24.539Z [config] ERROR: Found 2 Headscale processes: 15, 32
2025-06-22T17:48:24.539Z [config] ERROR: Integration Kubernetes (k8s) is not available
```
It's most likely an issue on headplane but if it's working correctly on your side I am curious on why (chart v0.3.0) and what value you used 
